### PR TITLE
Update `gym` imports to `gymnasium` (since openai/gym isn't maintained)

### DIFF
--- a/vgdl/interfaces/gym/__init__.py
+++ b/vgdl/interfaces/gym/__init__.py
@@ -1,4 +1,4 @@
-from gym.envs.registration import register
+from gymnasium.envs.registration import register
 from .env import VGDLEnv
 from .register_samples import register_sample_games
 

--- a/vgdl/interfaces/gym/env.py
+++ b/vgdl/interfaces/gym/env.py
@@ -1,7 +1,7 @@
 import os
 from collections import OrderedDict
-import gym
-from gym import spaces
+import gymnasium as gym
+from gymnasium import spaces
 import vgdl
 from vgdl.state import StateObserver
 import numpy as np

--- a/vgdl/interfaces/gym/list_space.py
+++ b/vgdl/interfaces/gym/list_space.py
@@ -1,4 +1,4 @@
-from gym import Space
+from gymnasium import Space
 
 class list_space(Space):
     def __init__(self, basespace):

--- a/vgdl/interfaces/gym/register_samples.py
+++ b/vgdl/interfaces/gym/register_samples.py
@@ -1,5 +1,5 @@
-import gym
-from gym.envs.registration import register
+import gymnasium as gym
+from gymnasium.envs.registration import register
 from vgdl.interfaces.gym import VGDLEnv
 import os
 

--- a/vgdl/util/humanplay/human.py
+++ b/vgdl/util/humanplay/human.py
@@ -6,7 +6,7 @@ import importlib
 import logging
 logger = logging.getLogger(__name__)
 
-import gym
+import gymnasium as gym
 
 
 class HumanController:
@@ -18,7 +18,7 @@ class HumanController:
             from .wrappers import AtariObservationWrapper
             self.env = AtariObservationWrapper(self.env)
         if trace_path is not None and importlib.util.find_spec('gym_recording') is not None:
-            from gym_recording.wrappers import TraceRecordingWrapper
+            from gymnasium_recording.wrappers import TraceRecordingWrapper
             self.env = TraceRecordingWrapper(self.env, trace_path)
         elif trace_path is not None:
             logger.warn('trace_path provided but could not find the gym_recording package')

--- a/vgdl/util/humanplay/list_envs.py
+++ b/vgdl/util/humanplay/list_envs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 def list_envs():
-    import gym
+    import gymnasium as gym
     import gym_vgdl
     env_names = list(gym.envs.registry.env_specs.keys())
     return env_names

--- a/vgdl/util/humanplay/play_vgdl.py
+++ b/vgdl/util/humanplay/play_vgdl.py
@@ -8,7 +8,7 @@ import numpy as np
 import argparse
 import logging
 
-import gym
+import gymnasium as gym
 
 import vgdl.interfaces.gym
 from .human import HumanVGDLController
@@ -16,7 +16,7 @@ from .human import HumanVGDLController
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def register_vgdl_env(domain_file, level_file, observer=None, blocksize=None):
-    from gym.envs.registration import register, registry
+    from gymnasium.envs.registration import register, registry
     level_name = '.'.join(os.path.basename(level_file).split('.')[:-1])
     env_name = 'vgdl_{}-v0'.format(level_name)
 


### PR DESCRIPTION
OpenAI doesn't actively maintain the Gym anymore, and the community is moving to using [farama-foundation/gymnasium][new-gym], so future installers might break.

(I've marked this as a draft because the Farama Foundation is supposed to be making some announcement on 11 Oct 2022 about this – so until then, the future of Gym is unclear (e.g. whether `gym` will be an actively published alias or if `gymnasium` will be).)

[new-gym]: https://github.com/farama-foundation/gymnasium